### PR TITLE
Handle plurals

### DIFF
--- a/plugins/plugin_word_respond.py
+++ b/plugins/plugin_word_respond.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from rtmbot.core import Plugin
 
 from utils import word_checking as wc_utils
-from utils.utils import load_json, write_json
+from utils.utils import load_json, write_json, add_plurals
 
 
 class PluginWordRespond(Plugin):
@@ -11,7 +11,7 @@ class PluginWordRespond(Plugin):
         # because of the way plugins are called we must explicitly pass the
         # arguments to the super
         super(PluginWordRespond, self).__init__(**kwargs)
-        self.words = load_json("words.json")
+        self.words = add_plurals(load_json("words.json"))
         self.opted_in = set(self._load_opted_in('opted_in.json'))
 
     def process_message(self, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 rtmbot==0.4.0
+inflect==0.2.5

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,5 +1,5 @@
 import json
-
+import inflect
 
 def load_json(filepath):
     with open(filepath) as json_file:
@@ -10,3 +10,14 @@ def load_json(filepath):
 def write_json(blob, filepath):
     with open(filepath, 'w') as json_file:
         json.dump(blob, json_file)
+
+def add_plurals(data):
+    p = inflect.engine()
+    plural_keys = []
+    plural_values = []
+    for key, subdict in data.iteritems():
+        plural_keys.append(p.plural(key))
+        plural_values.append(data[key])
+    plural_dict = dict(zip(plural_keys, plural_values))
+    data.update(plural_dict)
+    return data

--- a/utils/word_checking.py
+++ b/utils/word_checking.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import re
+
 from collections import Counter
 
 
@@ -10,7 +11,7 @@ def check_for_flag_words(message, words_array):
     pattern = r"[{}]".format(delims)
     message_array = re.split(pattern, message.lower())
     for word in message_array:
-        formatted_word = word.replace(u"\u2019", "").replace("'", "")
+        formatted_word = word.replace(u"\u2019s", "").replace(u"s\u2019", "s").replace("'s", "").replace("s'", "s")
         if formatted_word in words_array:
             cnt[formatted_word] += 1
     return dict(cnt)


### PR DESCRIPTION
Added a utils function `add_plurals` that takes the data loaded from the `words.json` file and adds the respective plural version of the word using inflect.

On init loads the `words.json` file then add the plurals of the words into `self.words` once

Update `word_checking.py` to handle apostrophes (both ascii version and `'`) and plurals:
- apple's -> apple
- apples' -> apples
