### PR TITLE
Remove numbers from the word to check for.

### DIFF
--- a/utils/word_checking.py
+++ b/utils/word_checking.py
@@ -11,7 +11,10 @@ def check_for_flag_words(message, words_array):
     pattern = r"[{}]".format(delims)
     message_array = re.split(pattern, message.lower())
     for word in message_array:
-        formatted_word = word.replace(u"\u2019s", "").replace(u"s\u2019", "s").replace("'s", "").replace("s'", "s")
+        # remove numbers from the word
+        text_word = re.sub("\d", "", word)
+        # handle apostrophes including unicode, ie. apple's -> apple and apples' -> apples
+        formatted_word = text_word.replace(u"\u2019s", "").replace(u"s\u2019", "s").replace("'s", "").replace("s'", "s")
         if formatted_word in words_array:
             cnt[formatted_word] += 1
     return dict(cnt)


### PR DESCRIPTION
Part 1: Remove any numbers from the word to check for. ie.
`123apples` -> `apples`,
`123banana's` -> `banana`,
`apple124` -> `apple`,
`banana123s'` -> `bananas`
`123pineapple456` -> `pineapple`

Part 2: Another PR to potentially refactor our current way of handling word variations.